### PR TITLE
certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ Visit https://localhost:9999 and authorize your Lichess account with this server
 If you are running the uvicorn server and want to rebuild the js files (and auto rebuild future changes):
 `./launchchess build`
 
+## production
+Assuming a running [traefik](https://traefik.io/traefik/) docker instance as a reverse proxy:
+
+### certs
+Playing with the [Lichess Board API](https://lichess.org/api#tag/Board) requires a valid https certificate. In addition, this must be served by the server itself (not the reverse proxy) in order to successfully generate an oauth token. 
+
+This is performed with the following label to the `docker-compose` file:
+``` yml
+...
+    - labels:
+      - traefik.tcp.routers.launchchess.tls.passthrough=true
+```
+
+Copying the traefik certificate is performed with:
+`./renew-cert.sh`
+
+### run
+`./launchchess p`
+
 ## python (offline only)
 LaunchChess can also be run as a standalone, headless python script (no website interface).
 

--- a/renew-cert.sh
+++ b/renew-cert.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# This script creates (or renews) a domain [$1] through certbot, then
+# copies the private key and certificate authority chain to a local file
 DIR=$(pwd)
 DOMAIN=launchchess.com
 docker-compose down


### PR DESCRIPTION
# Certs
Generate or renew certs

Bash script:
- stops docker containers
- stops `moat`
- runs `certbot` on requested domain `$1`
- restarts `moat`
- copies certfile and certificate authority chain to single file `priv.pem`
- restarts docker containers